### PR TITLE
Filter out `.` files

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -226,15 +226,15 @@ localesPaths.forEach(localesPath => {
               //const contextComment = '';
               switch(format) {
                 case 'js':
-                newLocaleContents = `${exportPrefix} ${formatJS(newLocaleContents)}`;
+                newLocaleContents = `${exportPrefix} ${formatJS(newLocaleContents)};`;
                 break;
 
                 case "js-quoted":
-                newLocaleContents = `${exportPrefix} ${newLocaleContents}`
+                newLocaleContents = `${exportPrefix} ${newLocaleContents};`
                 break;
 
                 case 'js-single-quoted':
-                newLocaleContents = `${exportPrefix} ${newLocaleContents.replace(/"(.+)":/g, "'$1:'")}`;
+                newLocaleContents = `${exportPrefix} ${newLocaleContents.replace(/"(.+)":/g, "'$1:'")};`;
                 break;
 
                 case "json":
@@ -245,7 +245,7 @@ localesPaths.forEach(localesPath => {
                 break;
               }
 
-              fs.writeFileSync(localePath, newLocaleContents + ';\n');
+              fs.writeFileSync(localePath, newLocaleContents + '\n');
             }
           }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -76,7 +76,9 @@ localesPaths.forEach(localesPath => {
     const sourceLocale = program.sourceLocale || source || globalSource;
     const allowedLocalesString = program.locales || configLocales || globalLocales;
     const allowedLocales = allowedLocalesString && allowedLocalesString.split(',');
-    const filteredFiles = !allowedLocales ? files : files.filter(file => allowedLocales.includes(file.replace(`.${ext}`, '')) || file === sourceLocale + `.${ext}`);
+    const filteredFiles = !allowedLocales ?
+      files.filter(file => !(/(^|\/)\.[^\/\.]/g).test(file)) :
+      files.filter(file => allowedLocales.includes(file.replace(`.${ext}`, '')) || file === sourceLocale + `.${ext}`);
 
     Promise.all(filteredFiles.map(file => readFile(absLocalesPath + file, 'utf8')))
     .then((res) => {

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -245,7 +245,7 @@ localesPaths.forEach(localesPath => {
                 break;
               }
 
-              fs.writeFileSync(localePath, newLocaleContents + '\n');
+              fs.writeFileSync(localePath, newLocaleContents + ';\n');
             }
           }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -77,7 +77,7 @@ localesPaths.forEach(localesPath => {
     const allowedLocalesString = program.locales || configLocales || globalLocales;
     const allowedLocales = allowedLocalesString && allowedLocalesString.split(',');
     const filteredFiles = !allowedLocales ?
-      files.filter(file => !(/(^|\/)\.[^\/\.]/g).test(file)) :
+      files.filter(file => !(/^\..*/g).test(file)) :
       files.filter(file => allowedLocales.includes(file.replace(`.${ext}`, '')) || file === sourceLocale + `.${ext}`);
 
     Promise.all(filteredFiles.map(file => readFile(absLocalesPath + file, 'utf8')))


### PR DESCRIPTION
This allows placing something like a .eslintrc.json file in the folder with lang files.