### PR TITLE
Add sort command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "Validates that ICU MessageFormat strings are well-formed, and that translated target strings are compatible with their source.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The sort command will rewrite files, sorting strings alphabetically, maintaining any blocks.

e.g.

```javascript
{
  "b:2": "Be two",
  "b:1": "Be one",

  "a:1": "A one",

  "c": "See"
}
```

becomes:

```javascript
{
  "a:1": "A one",

  "b:1": "Be one",
  "b:2": "Be two",

  "c": "See"
}
```