### PR TITLE
Fix nbsp issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Validates that ICU MessageFormat strings are well-formed, and that translated target strings are compatible with their source.",
   "repository": {
     "type": "git",

--- a/src/validate.js
+++ b/src/validate.js
@@ -113,7 +113,7 @@ function validateString({ targetString, targetLocale, sourceString, sourceLocale
     }
 
     // remove all translated content, leaving only the messageformat structure
-    const regx = new RegExp(targetMap.stringTokens.map(t => t.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')).join('|'), 'g');
+    const regx = new RegExp(targetMap.stringTokens.map(t => t.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')).filter(s => s !== '\\ ').join('|'), 'g');
     const structure = targetString.replace(regx, m => Array(m.length).fill(' ').join('')); // eslint-disable-line newline-per-chained-call
 
     const newlinePos = structure.indexOf(String.fromCharCode(10));


### PR DESCRIPTION
When generating the regex to remove translatable content, a string of a single space will globally remove all spaces from the targetString. This causes any subsequent matching to fail, leaving translatable content in the `structure`, which is then searched for non-breaking spaces.

Ultimately the generated regex needs to be rewritten to not use the global flag, as this can still happen with other short strings that may have multiple matches in the `targetString`.

Fixes issue https://github.com/bearfriend/messageformat-validator/issues/19
