### PR TITLE
Handle jsonObj reverse key order

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -127,6 +127,7 @@ localesPaths.forEach(localesPath => {
         const matches = Array.from(contents.matchAll(regex));//.map(m => m.groups);
 
         let findContext = false;
+        let findValue = false;
 
         matches.forEach(match => {
 
@@ -137,13 +138,29 @@ localesPaths.forEach(localesPath => {
               return;
             }
 
-            if (match.groups.key === 'translation' && match.groups.realKey) {
+            if (findValue && match.groups.key === 'translation') {
+              acc[locale].parsed[findValue].val = match.groups.val;
+              findValue = false;
+              return;
+            }
+
+            if (match.groups.realKey) {
+
+              if (match.groups.key === 'translation') {
+                findContext = match.groups.realKey;
+              }
+              if (match.groups.key === 'context') {
+                match.groups.comment = match.groups.val;
+                findValue = match.groups.realKey;
+              }
+
               match.groups.key = match.groups.realKey;
-              findContext = match.groups.key;
             }
           }
 
-          acc[locale].parsed[match.groups.key] = Object.assign(String(match[0]), match.groups);
+          if (!acc[locale].parsed[match.groups.key]) {
+            acc[locale].parsed[match.groups.key] = Object.assign(String(match[0]), match.groups);
+          }
         });
         return acc;
       }, {});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Validates that ICU MessageFormat strings are well-formed, and that translated target strings are compatible with their source.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Previously objects were only handled correctly if the keys were in the order `['translation', 'context']`. This PR adds support for `['context', 'translation']` as well.