### PR TITLE
Various fixes and improvements

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -120,11 +120,12 @@ localesPaths.forEach(localesPath => {
 
         const useJSONObj = program.jsonObj || jsonObj || globalJsonObj;
 
-        //             [                   ][  ][         "       ][   key   ][     "    ][             ][:][             ][        "       ][     value    ][        "        ][     ,    ][ // comment ]
         const regex = useJSONObj
-          ? /("(?<realKey>.*)"(\s?):(\s?){)*\s+(?<keyQuote>["'`]?)(?<key>.*?)\k<keyQuote>(?<keySpace>\s?):(?<valSpace>\s?)(?<valQuote>["'`])(?<val>(.|\n)*?)(?<!\\)\k<valQuote>(?<comma>,?)(?<comment>.*)/g
-          : /\s+(?<keyQuote>["'`]?)(?<key>.*?)\k<keyQuote>(?<keySpace>\s?):(?<valSpace>\s?)(?<valQuote>["'`])(?<val>(.|\n)*?)(?<!\\)\k<valQuote>(?<comma>,?)(?<comment>.*)/g;
-        const matches = Array.from(contents.matchAll(regex));//.map(m => m.groups);
+          //[                             ][  ][         "       ][   key   ][     "    ][             ][:][             ][        "       ][     value    ][        "        ][     ,    ][ // comment ]
+          ? /("(?<realKey>.*)"(\s*):(\s*){)*\s+(?<keyQuote>["'`]?)(?<key>.*?)\k<keyQuote>(?<keySpace>\s*):(?<valSpace>\s*)(?<valQuote>["'`])(?<val>(.|\n)*?)(?<!\\)\k<valQuote>(?<comma>,?)(?<comment>.*)/g
+          //[  ][         "       ][   key   ][     "    ][             ][:][             ][        "       ][     value    ][        "        ][     ,    ][ // comment ]
+          : /\s+(?<keyQuote>["'`]?)(?<key>.*?)\k<keyQuote>(?<keySpace>\s*):(?<valSpace>\s*)(?<valQuote>["'`])(?<val>(.|\n)*?)(?<!\\)\k<valQuote>(?<comma>,?)(?<comment>.*)/g;
+        const matches = Array.from(contents.matchAll(regex));
 
         let findContext = false;
         let findValue = false;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,7 +14,7 @@ const findConfig = require('find-config');
 const configPath = findConfig('mfv.config.json');
 const { version } = require('../package.json');
 const { path, source: globalSource, locales: globalLocales, jsonObj: globalJsonObj } = configPath ? require(configPath) : {};
-const { validateLocales } = require('../src/validate');
+const { validateLocales, structureRegEx } = require('../src/validate');
 
 require = require('esm')(module) // eslint-disable-line
 
@@ -172,8 +172,6 @@ localesPaths.forEach(localesPath => {
           .replace(/\t/g, '··')
           .replace(/\n/g, '␤\n');
 
-        const re = /(?<=\s*){(.|\n)*?({|})|\s*}(.|\n)*?{|[{#]|(\s*)}/g;
-
         Object.keys(locales).forEach(locale => {
           if ((!allowedLocales || allowedLocales.includes(locale)) && locales[locale].parsed[program.highlight]) {
             const str = String(locales[locale].parsed[program.highlight].val);
@@ -182,7 +180,7 @@ localesPaths.forEach(localesPath => {
             let prevEnd = 0;
             const sections = [];
 
-            while((match = re.exec(str)) !== null) {
+            while((match = structureRegEx.exec(str)) !== null) {
               sections.push(showWS(str.substring(prevEnd, match.index)));
               sections.push(chalk.red(showWS(str.substr(match.index, match[0].length))));
               prevEnd = match.index + match[0].length;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "Validates that ICU MessageFormat strings are well-formed, and that translated target strings are compatible with their source.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Update structure regex to match split terms correctly
- Replace old flawed structure detector with new structure regex
- Ignore "untranslated" strings that are entirely structure/punctuation/whitespace
- Support `mfv-translated` overrides
- Support multiple whitespace characters between keys and values