### PR TITLE
fix: Throw explicit error when path is missing

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -72,7 +72,10 @@ program
 
 program.parse(process.argv);
 
-const localesPaths = glob.sync(program.path || path);
+const pathCombined = program.path || path;
+if (!pathCombined) throw new Error('Must provide a path to the locale files using either the -p option or a config file.');
+
+const localesPaths = glob.sync(pathCombined);
 localesPaths.forEach(localesPath => {
 
   const absLocalesPath = `${process.cwd()}/${localesPath}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Validates that ICU MessageFormat strings are well-formed, and that translated target strings are compatible with their source.",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Ran into this problem when using `mfv rename` - it was obvious when I realized my mistake, but the existing error message wasn't helping. It was failing on [CLI line 75](https://github.com/bearfriend/messageformat-validator/blob/master/bin/cli.js#L75) with:

```
Error: must provide pattern
    at new GlobSync (C:\D2L\BrightspaceUI\core\node_modules\glob\sync.js:28:11)
    at Function.globSync [as sync] (C:\D2L\BrightspaceUI\core\node_modules\glob\sync.js:23:10)
    at Object.<anonymous> (C:\D2L\BrightspaceUI\core\node_modules\messageformat-validator\bin\cli.js:75:27)
```