### PR TITLE
Added Duplicate Keys Check

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -117,6 +117,7 @@ localesPaths.forEach(localesPath => {
         const locale = file.split('.')[0];
         acc[locale] = {
           contents,
+          duplicateKeys: new Set(),
           parsed: {},
           file
         };
@@ -164,6 +165,8 @@ localesPaths.forEach(localesPath => {
 
           if (!acc[locale].parsed[match.groups.key]) {
             acc[locale].parsed[match.groups.key] = Object.assign(String(match[0]), match.groups);
+          } else {
+            acc[locale].duplicateKeys.add(match.groups.key);
           }
         });
         return acc;

--- a/src/validate.js
+++ b/src/validate.js
@@ -29,6 +29,8 @@ function validateLocales({ locales, sourceLocale }) {
 
       if (!sourceString) reporter.error('extraneous', 'This string does not exist in the source file.');
 
+      if (locales[targetLocale].duplicateKeys.has(key)) reporter.error('duplicate-keys', 'Key appears multiple times');
+
       validateString({
         targetString,
         targetLocale,


### PR DESCRIPTION
I noticed that if you use the same name for lang terms, then it was only ever making use of the first case, but wasn't notifying the user of potential issues with other instances of the same name. So I'm making a change so that it notifies the user by throwing an error (labelled `duplicate-keys`) if two or more lang terms share the same key, so that they can review their lang terms to avoid repeating ones.