### PR TITLE
Move to esm, provide exports, and various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ Some options can be configured with default values in `mfv.config.json`
 
 ## Warnings
 
+`categories` - The target message is missing plural categories used in the target locale
+
 `nest` - There is a `select` nested inside a `plural` or `selectordinal` in the target message.
 
 `split` - The target message is split by a non-argument. `plural`, `selectordinal`, and `select` cases should contain complete translations.

--- a/README.md
+++ b/README.md
@@ -100,9 +100,7 @@ Some options can be configured with default values in `mfv.config.json`
 
 ## Warnings
 
-`newline` - There are unnecessary newline characters in the target string.
-
-`nest` - There is a `plural` nested inside a `select` in the target string.
+`nest` - There is a `select` nested inside a `plural` or `selectordinal` in the target string.
 
 `split` - The target string is split by a non-argument. `plural` and `select` cases should contain complete sentences/strings.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # messageformat-validator
 
-Validates messageformat strings against various errors and warnings.
+Validates messageformat messages against various errors and warnings.
 
 ## Install
 
@@ -21,50 +21,50 @@ Check for issues in all files within `lang/`
 mfv -s en -p lang/
 ```
 
-Add strings that exist in `en` to all files witin `lang/`, if they are missing
+Add messages that exist in `en` to all files within `lang/`, if they are missing
 ```shell
 mfv -s en -p lang/ add-missing
 ```
 
-Output the `example-translation` string from the `es-es` file with all messageformat structure highlighted
+Output the `myMessage` message from the `es-es` file with all messageformat structure highlighted
 ```shell
-mfv -l es-es -p lang/ highlight example-translation
+mfv -l es-es -p lang/ highlight myMessage
 ```
 
 ### Options:
 
 `-V, --version` - output the version number
-  
+
 `-e, --throw-errors` - Throw an error if error issues are found
-  
+
 `--no-issues` - Don't output issues
-  
+
 `-i, --ignoreIssueTypes <items>` - Ignore these comma-separated issue types
-  
+
 `-l, --locales <items>` - Process only these comma-separated locales
-  
+
 `-p, --path <path>` - Path to a directory containing locale files
-  
-`-t, --translator-output` - Output JSON of all source strings that are missing or untranslated in the target
-  
+
+`-t, --translator-output` - Output JSON of all source messages that are missing or untranslated in the target
+
 `-s, --source-locale <locale>` - The locale to use as the source
 
 `--json-obj` - Indicate that the files to be parsed are JSON files with keys that have objects for values with their own keys: `translation` and `context`
-  
+
 `-h, --help` - display help for command
 
 ### Subommands:
-  
-`remove-extraneous` - Remove strings that do not exist in the source locale
-  
-`add-missing` - Add strings that do not exist in the target locale
 
-`sort` - Sort strings alphabetically by key, maintaining any blocks
-  
-`rename <old-key> <new-key>` - Rename a string
+`remove-extraneous` - Remove messages that do not exist in the source locale
 
-`highlight <key>` - Output a string with all non-translatable ICU MessageFormat structure highlighted
-  
+`add-missing` - Add messages that do not exist in the target locale
+
+`sort` - Sort messages alphabetically by key, maintaining any blocks
+
+`rename <old-key> <new-key>` - Rename a message
+
+`highlight <key>` - Output a message with all non-translatable ICU MessageFormat structure highlighted
+
 `help [command]` - display help for command
 
 ## Config File
@@ -74,34 +74,37 @@ Some options can be configured with default values in `mfv.config.json`
 {
   "source": "en"
   "path": "lang/",
-  "locales": "ar,de,en,es,es-es,hi,tr"
+  "locales": "ar,de,en,es,es-es,hi,tr",
+  "jsonObj": true
 }
 ```
 
 ## Errors
 
-`argument` - There are unrecognized arguments in the target string.
+`argument` - There are unrecognized arguments in the target message.
 
-`brace` - There are mismatched braces in the target string.
+`brace` - There are mismatched braces in the target message.
 
-`case` - There are unrecognized cases in the target string.
+`case` - There are unrecognized cases in the target message.
 
-`extraneous` - There is an extraneous key/string in the target locale.
+`extraneous` - There is an extraneous message in the target locale.
 
-`missing` - There is a key/string missing from the target locale.
+`missing` - There is a message missing from the target locale.
 
-`nbsp` - There are invalid non-breaking spaces in the structure of the target string.
+`nbsp` - There are invalid non-breaking spaces in the structure of the target message.
 
-`nest` - The nesting order of the target string does not match the source string.
+`nest` - The nesting order of the target message does not match the source message.
 
-`parse` - The target string can not be parsed.
+`other` - The target message is missing an `other` case
 
-`source` - There is an error in the source string.
+`parse` - The target message can not be parsed.
+
+`source` - There is an error in the source message.
 
 ## Warnings
 
-`nest` - There is a `select` nested inside a `plural` or `selectordinal` in the target string.
+`nest` - There is a `select` nested inside a `plural` or `selectordinal` in the target message.
 
-`split` - The target string is split by a non-argument. `plural` and `select` cases should contain complete sentences/strings.
+`split` - The target message is split by a non-argument. `plural`, `selectordinal`, and `select` cases should contain complete translations.
 
-`untranslated` - The target string has not been translated.
+`untranslated` - The target message has not been translated.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,25 +1,20 @@
-#!/usr/bin/env node
-
-'use strict';
+#!/usr/bin/env NODE_OPTIONS=--no-warnings node
 
 /* eslint-disable no-console */
 
-const fs = require('fs');
-const { promisify } = require('util');
-const chalk = require('chalk');
-const glob = require('glob');
-const readFile = promisify(fs.readFile);
-const { program } = require('commander');
-const findConfig = require('find-config');
-const configPath = findConfig('mfv.config.json');
-const { version } = require('../package.json');
-const { path, source: globalSource, locales: globalLocales, jsonObj: globalJsonObj } = configPath ? require(configPath) : {};
-const { validateLocales, structureRegEx } = require('../src/validate');
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import chalk from 'chalk';
+import glob from 'glob';
+import { program } from 'commander';
+import findConfig from 'find-config';
+import pkg from '../package.json' with { type: 'json' };
+import { validateLocales, structureRegEx } from '../src/validate.js';
 
-require = require('esm')(module) // eslint-disable-line
+const configPath = findConfig('mfv.config.json');
+const { path, source: globalSource, locales: globalLocales, jsonObj: globalJsonObj } = configPath ? await import(configPath) : {};
 
 program
-  .version(version)
+  .version(pkg.version)
   .option('-e, --throw-errors', 'Throw an error if error issues are found')
   .option('--no-issues', 'Don\'t output issues')
   .option('-i, --ignoreIssueTypes <items>', 'Ignore these comma-separated issue types')
@@ -76,280 +71,277 @@ const pathCombined = program.path || path;
 if (!pathCombined) throw new Error('Must provide a path to the locale files using either the -p option or a config file.');
 
 const localesPaths = glob.sync(pathCombined);
-localesPaths.forEach(localesPath => {
+localesPaths.forEach(async localesPath => {
 
   const absLocalesPath = `${process.cwd()}/${localesPath}`;
 
   const subConfigPath = findConfig('mfv.config.json', { cwd: absLocalesPath });
 
-  const { source, locales: configLocales, jsonObj } = subConfigPath ? require(subConfigPath) : {}; /* eslint-disable-line global-require */
+  const { source, locales: configLocales, jsonObj } = subConfigPath ? await import(subConfigPath) : {}; /* eslint-disable-line global-require */
 
-  fs.readdir(absLocalesPath, (err, files) => {
-    if (err) {
-      console.log(`Failed to read ${absLocalesPath}`);
-      return;
-    }
+  const files = await readdir(absLocalesPath).catch(err => console.log(`Failed to read ${absLocalesPath}`));
+  if (!files) return;
 
-    const sourceLocale = program.sourceLocale || source || globalSource;
-    const allowedLocalesString = program.locales || configLocales || globalLocales;
-    const allowedLocales = allowedLocalesString && allowedLocalesString.split(',').concat(sourceLocale);
-    const filteredFiles = !allowedLocales ?
-      files.filter(file => !(/^\..*/g).test(file)) :
-      files.filter(file => allowedLocales.includes(file.split('.')[0]));
-    const targetLocales = filteredFiles.map(file => file.split('.')[0]);
+  const sourceLocale = program.sourceLocale || source || globalSource;
+  const allowedLocalesString = program.locales || configLocales || globalLocales;
+  const allowedLocales = allowedLocalesString && allowedLocalesString.split(',').concat(sourceLocale);
+  const filteredFiles = !allowedLocales ?
+    files.filter(file => !(/^\..*/g).test(file)) :
+    files.filter(file => allowedLocales.includes(file.split('.')[0]));
+  const targetLocales = filteredFiles.map(file => file.split('.')[0]);
 
-    if (program.removeExtraneous) {
-      console.log('Removing extraneous strings from:', targetLocales.join(', '));
-    }
+  if (program.removeExtraneous) {
+    console.log('Removing extraneous strings from:', targetLocales.join(', '));
+  }
 
-    if (program.addMissing) {
-      console.log('Adding missing strings to:', targetLocales.join(', '));
-    }
+  if (program.addMissing) {
+    console.log('Adding missing strings to:', targetLocales.join(', '));
+  }
 
-    if (program.rename) {
-      console.log(`Renaming "${program.oldKey}" to "${program.newKey}" in:`, targetLocales.join(', '));
-    }
+  if (program.rename) {
+    console.log(`Renaming "${program.oldKey}" to "${program.newKey}" in:`, targetLocales.join(', '));
+  }
 
-    Promise.all(filteredFiles.map(file => readFile(absLocalesPath + file, 'utf8')))
-    .then(res => {
-      const locales = res.reduce((acc, contents, idx) => {
-        const file = filteredFiles[idx];
-        const locale = file.split('.')[0];
-        acc[locale] = {
-          contents,
-          duplicateKeys: new Set(),
-          parsed: {},
-          file
-        };
-
-        const useJSONObj = program.jsonObj || jsonObj || globalJsonObj;
-
-        const regex = useJSONObj
-          //[                             ][  ][         "       ][   key   ][     "    ][             ][:][             ][        "       ][     value    ][        "        ][     ,    ][ // comment ]
-          ? /("(?<realKey>.*)"(\s*):(\s*){)*\s+(?<keyQuote>["'`]?)(?<key>.*?)\k<keyQuote>(?<keySpace>\s*):(?<valSpace>\s*)(?<valQuote>["'`])(?<val>(.|\n)*?)(?<!\\)\k<valQuote>(?<comma>,?)(?<comment>.*)/g
-          //[  ][         "       ][   key   ][     "    ][             ][:][             ][        "       ][     value    ][        "        ][     ,    ][ // comment ]
-          : /\s+(?<keyQuote>["'`]?)(?<key>.*?)\k<keyQuote>(?<keySpace>\s*):(?<valSpace>\s*)(?<valQuote>["'`])(?<val>(.|\n)*?)(?<!\\)\k<valQuote>(?<comma>,?)(?<comment>.*)/g;
-        const matches = Array.from(contents.matchAll(regex));
-
-        let findContext = false;
-        let findValue = false;
-
-        matches.forEach(match => {
-
-          if (useJSONObj) {
-            if (findContext && match.groups.key === 'context') {
-              acc[locale].parsed[findContext].comment = match.groups.val;
-              findContext = false;
-              return;
-            }
-
-            if (findValue && match.groups.key === 'translation') {
-              acc[locale].parsed[findValue].val = match.groups.val;
-              findValue = false;
-              return;
-            }
-
-            if (match.groups.realKey) {
-
-              if (match.groups.key === 'translation') {
-                findContext = match.groups.realKey;
-              }
-              if (match.groups.key === 'context') {
-                match.groups.comment = match.groups.val;
-                findValue = match.groups.realKey;
-              }
-
-              match.groups.key = match.groups.realKey;
-            }
-          }
-
-          if (!acc[locale].parsed[match.groups.key]) {
-            acc[locale].parsed[match.groups.key] = Object.assign(String(match[0]), match.groups);
-          } else {
-            acc[locale].duplicateKeys.add(match.groups.key);
-          }
-        });
-        return acc;
-      }, {});
-
-      if (program.highlight) {
-
-        const showWS = str => str
-          .replace(/ /g, '·')
-          .replace(/\t/g, '··')
-          .replace(/\n/g, '␤\n');
-
-        Object.keys(locales).forEach(locale => {
-          if ((!allowedLocales || allowedLocales.includes(locale)) && locales[locale].parsed[program.highlight]) {
-            const str = String(locales[locale].parsed[program.highlight].val);
-
-            let match;
-            let prevEnd = 0;
-            const sections = [];
-
-            while((match = structureRegEx.exec(str)) !== null) {
-              sections.push(showWS(str.substring(prevEnd, match.index)));
-              sections.push(chalk.red(showWS(str.substr(match.index, match[0].length))));
-              prevEnd = match.index + match[0].length;
-            }
-
-            sections.push(showWS(str.substring(prevEnd)));
-
-            const highlighted = sections.join('');
-            console.log(highlighted);
-
-          }
-        });
-
-        return;
-      }
-
-      if (program.rename) {
-        let count = 0;
-        Object.keys(locales).forEach(locale => {
-          if (!allowedLocales || allowedLocales.includes(locale)) {
-
-            const localeContents = locales[locale].contents;
-            const t = locales[locale].parsed[program.oldKey];
-
-            if (localeContents.includes(t)) {
-              const old = `${t.keyQuote}${t.key}${t.keyQuote}${t.keySpace}:${t.valSpace}${t.valQuote}${t.val}`;
-              const noo = `${t.keyQuote}${program.newKey}${t.keyQuote}${t.keySpace}:${t.valSpace}${t.valQuote}${t.val}`;
-
-              count += 1;
-              const newLocaleContents = localeContents.replace(old, noo);
-
-              fs.writeFileSync(absLocalesPath + locales[locale].file, newLocaleContents);
-              console.log(`${chalk.green('\u2714')} ${locales[locale].file} - Renamed`);
-            }
-            else {
-              console.log(`${chalk.red('\u2716')} ${locales[locale].file} - Missing`);
-            }
-          }
-        });
-
-        const cliReport = `\n ${chalk.green('\u2714')} Renamed ${count} strings`;
-        console.log(cliReport);
-
-        return;
-      }
-
-      const output = validateLocales({ locales, sourceLocale });
-      const translatorOutput = {};
-
-      output.forEach((locale, idx) => {
-        const localePath = `${absLocalesPath}${locales[locale.locale].file}`;
-
-        if (!allowedLocales || allowedLocales.includes(locale.locale)) {
-          console.log((idx > 0 ? '\n' : '') + chalk.underline(localePath));
-          if (program.issues) {
-
-            locale.report.totals.ignored = 0;
-
-            if (program.sort) {
-              const sorted = Object.values(locales[locale.locale].parsed)
-              .reduce((acc, val) => {
-                const block = !val.startsWith('\n\n') ? acc.pop() || [] : [];
-                block.push(val.replace('\n\n', '\n'));
-                acc.push(block);
-                return acc;
-              }, [])
-              .map(block => block.sort().join(''))
-              .sort()
-              .join('\n');
-
-              locales[locale.locale].contents = locales[locale.locale].contents.replace(Object.values(locales[locale.locale].parsed).join(''), sorted);
-            }
-            else {
-
-              locale.issues.forEach((issue) => {
-                if (program.removeExtraneous) {
-                  if (issue.type === 'extraneous') {
-                    locales[locale.locale].contents = locales[locale.locale].contents.replace(locales[locale.locale].parsed[issue.key], '')
-                    console.log('Removed:', issue.key);
-                  }
-                }
-                else if (program.addMissing) {
-                  if (issue.type === 'missing') {
-                    const keys = Object.keys(locales[sourceLocale].parsed);
-                    const targetKeys = Object.keys(locales[locale.locale].parsed);
-                    const keyIdx = keys.indexOf(issue.key);
-                    const nextKey = keys[keyIdx + 1];
-                    const previousKey = keys[keyIdx - 1];
-                    const nextString = locales[locale.locale].parsed[nextKey];
-                    const siblingString = nextString || locales[locale.locale].parsed[previousKey] || locales[locale.locale].parsed[targetKeys[targetKeys.length - 1]];
-                    const contents = locales[locale.locale].contents;
-                    const insertAt = contents.indexOf(siblingString) + Number(!nextString ? String(siblingString).length : 0);
-                    const comma = !nextString && !siblingString.comma ? `,${siblingString.comment}` : '';
-                    const commaOffset = comma ? siblingString.comment.length : 0;
-                    const sourceString = `${comma}${locales[sourceLocale].parsed[issue.key]}`;
-                    locales[locale.locale].contents = [contents.slice(0, insertAt - commaOffset), sourceString, contents.slice(insertAt)].join('');
-                    console.log('Added:', issue.key);
-                    locales[locale.locale].parsed[issue.key] = locales[sourceLocale].parsed[issue.key];
-                  }
-                }
-                else if (program.translatorOutput) {
-                  if (['missing', 'untranslated'].includes(issue.type)) {
-                    translatorOutput[issue.key] = issue.source;
-                  }
-                }
-                else if (!program.ignoreIssueTypes || !program.ignoreIssueTypes.replace(' ','').split(',').includes(issue.type)) {
-                  console.log([
-                    '  ', chalk.grey(`${issue.line}:${issue.column}`),
-                    '  ', chalk[issue.level == 'error' ? 'red' : 'yellow'](issue.level),
-                    ' ', chalk.grey(issue.type),
-                    '  ', chalk.cyan(issue.key),
-                    '  ', chalk.white(issue.msg)
-                  ].join(''));
-                }
-                else {
-                  locale.report.totals.ignored += 1;
-                }
-              });
-            }
-
-            if (program.removeExtraneous || program.addMissing || program.sort) {
-              fs.writeFileSync(localePath, locales[locale.locale].contents);
-            }
-          }
-
-          if (program.translatorOutput) {
-            console.log(JSON.stringify(translatorOutput, null, 2));
-          }
-
-          if (program.removeExtraneous) {
-            const count = locale.report.errors ? locale.report.errors.extraneous || 0 : 0;
-            const cliReport = `\n ${chalk.green('\u2714')} Removed ${count} extraneous strings`;
-            console.log(cliReport);
-          }
-          else if (program.addMissing) {
-            const count = locale.report.errors ? locale.report.errors.missing || 0 : 0;
-            const cliReport = `\n ${chalk.green('\u2714')} Added ${count} missing strings`;
-            console.log(cliReport);
-          }
-          else if (program.sort) {
-            console.log('\nSorted');
-          }
-          else if (locale.report.totals.errors || locale.report.totals.warnings) {
-            const color = locale.report.totals.errors ? 'red' : 'yellow';
-            const total = locale.report.totals.errors + locale.report.totals.warnings;
-            const cliReport = chalk[color](`\n\u2716 ${total} issues (${locale.report.totals.errors} errors, ${locale.report.totals.warnings} warnings)${locale.report.totals.ignored ? chalk.grey(` - ${locale.report.totals.ignored} Ignored`) : ''}`);
-            console.log(cliReport);
-          }
-          else {
-            const cliReport = `\n ${chalk.green('\u2714')} Passed`;
-            console.log(cliReport);
-          }
-        }
-      });
-
-      if (program.throwErrors && output.some(locale => locale.report.totals.errors)) {
-        throw new Error('Errors were reported in at least one locale. See details above.');
-      }
-    })
-    .catch((errAll) => {
-      console.error(errAll);
+  const res = await Promise.all(filteredFiles.map(file => readFile(absLocalesPath + file, 'utf8')))
+    .catch(err => {
+      console.error(err);
       process.exitCode = 1;
     });
+
+  if (!res) return;
+
+  const locales = res.reduce((acc, contents, idx) => {
+    const file = filteredFiles[idx];
+    const locale = file.split('.')[0];
+    acc[locale] = {
+      contents,
+      duplicateKeys: new Set(),
+      parsed: {},
+      file
+    };
+
+    const useJSONObj = program.jsonObj || jsonObj || globalJsonObj;
+
+    const regex = useJSONObj
+      //[                             ][  ][         "       ][   key   ][     "    ][             ][:][             ][        "       ][     value    ][        "        ][     ,    ][ // comment ]
+      ? /("(?<realKey>.*)"(\s*):(\s*){)*\s+(?<keyQuote>["'`]?)(?<key>.*?)\k<keyQuote>(?<keySpace>\s*):(?<valSpace>\s*)(?<valQuote>["'`])(?<val>(.|\n)*?)(?<!\\)\k<valQuote>(?<comma>,?)(?<comment>.*)/g
+      //[  ][         "       ][   key   ][     "    ][             ][:][             ][        "       ][     value    ][        "        ][     ,    ][ // comment ]
+      : /\s+(?<keyQuote>["'`]?)(?<key>.*?)\k<keyQuote>(?<keySpace>\s*):(?<valSpace>\s*)(?<valQuote>["'`])(?<val>(.|\n)*?)(?<!\\)\k<valQuote>(?<comma>,?)(?<comment>.*)/g;
+    const matches = Array.from(contents.matchAll(regex));
+
+    let findContext = false;
+    let findValue = false;
+
+    matches.forEach(match => {
+
+      if (useJSONObj) {
+        if (findContext && match.groups.key === 'context') {
+          acc[locale].parsed[findContext].comment = match.groups.val;
+          findContext = false;
+          return;
+        }
+
+        if (findValue && match.groups.key === 'translation') {
+          acc[locale].parsed[findValue].val = match.groups.val;
+          findValue = false;
+          return;
+        }
+
+        if (match.groups.realKey) {
+
+          if (match.groups.key === 'translation') {
+            findContext = match.groups.realKey;
+          }
+          if (match.groups.key === 'context') {
+            match.groups.comment = match.groups.val;
+            findValue = match.groups.realKey;
+          }
+
+          match.groups.key = match.groups.realKey;
+        }
+      }
+
+      if (!acc[locale].parsed[match.groups.key]) {
+        acc[locale].parsed[match.groups.key] = Object.assign(String(match[0]), match.groups);
+      } else {
+        acc[locale].duplicateKeys.add(match.groups.key);
+      }
+    });
+    return acc;
+  }, {});
+
+  if (program.highlight) {
+
+    const showWS = str => str
+      .replace(/ /g, '·')
+      .replace(/\t/g, '··')
+      .replace(/\n/g, '␤\n');
+
+    Object.keys(locales).forEach(locale => {
+      if ((!allowedLocales || allowedLocales.includes(locale)) && locales[locale].parsed[program.highlight]) {
+        const str = String(locales[locale].parsed[program.highlight].val);
+
+        let match;
+        let prevEnd = 0;
+        const sections = [];
+
+        while((match = structureRegEx.exec(str)) !== null) {
+          sections.push(showWS(str.substring(prevEnd, match.index)));
+          sections.push(chalk.red(showWS(str.substr(match.index, match[0].length))));
+          prevEnd = match.index + match[0].length;
+        }
+
+        sections.push(showWS(str.substring(prevEnd)));
+
+        const highlighted = sections.join('');
+        console.log(highlighted);
+
+      }
+    });
+
+    return;
+  }
+
+  if (program.rename) {
+    let count = 0;
+    Object.keys(locales).forEach(async locale => {
+      if (!allowedLocales || allowedLocales.includes(locale)) {
+
+        const localeContents = locales[locale].contents;
+        const t = locales[locale].parsed[program.oldKey];
+
+        if (localeContents.includes(t)) {
+          const old = `${t.keyQuote}${t.key}${t.keyQuote}${t.keySpace}:${t.valSpace}${t.valQuote}${t.val}`;
+          const noo = `${t.keyQuote}${program.newKey}${t.keyQuote}${t.keySpace}:${t.valSpace}${t.valQuote}${t.val}`;
+
+          count += 1;
+          const newLocaleContents = localeContents.replace(old, noo);
+
+          await writeFile(absLocalesPath + locales[locale].file, newLocaleContents);
+          console.log(`${chalk.green('\u2714')} ${locales[locale].file} - Renamed`);
+        }
+        else {
+          console.log(`${chalk.red('\u2716')} ${locales[locale].file} - Missing`);
+        }
+      }
+    });
+
+    const cliReport = `\n ${chalk.green('\u2714')} Renamed ${count} strings`;
+    console.log(cliReport);
+
+    return;
+  }
+
+  const output = validateLocales({ locales, sourceLocale });
+  const translatorOutput = {};
+
+  output.forEach(async(locale, idx) => {
+    const localePath = `${absLocalesPath}${locales[locale.locale].file}`;
+
+    if (!allowedLocales || allowedLocales.includes(locale.locale)) {
+      console.log((idx > 0 ? '\n' : '') + chalk.underline(localePath));
+      if (program.issues) {
+
+        locale.report.totals.ignored = 0;
+
+        if (program.sort) {
+          const sorted = Object.values(locales[locale.locale].parsed)
+          .reduce((acc, val) => {
+            const block = !val.startsWith('\n\n') ? acc.pop() || [] : [];
+            block.push(val.replace('\n\n', '\n'));
+            acc.push(block);
+            return acc;
+          }, [])
+          .map(block => block.sort().join(''))
+          .sort()
+          .join('\n');
+
+          locales[locale.locale].contents = locales[locale.locale].contents.replace(Object.values(locales[locale.locale].parsed).join(''), sorted);
+        }
+        else {
+
+          locale.issues.forEach((issue) => {
+            if (program.removeExtraneous) {
+              if (issue.type === 'extraneous') {
+                locales[locale.locale].contents = locales[locale.locale].contents.replace(locales[locale.locale].parsed[issue.key], '')
+                console.log('Removed:', issue.key);
+              }
+            }
+            else if (program.addMissing) {
+              if (issue.type === 'missing') {
+                const keys = Object.keys(locales[sourceLocale].parsed);
+                const targetKeys = Object.keys(locales[locale.locale].parsed);
+                const keyIdx = keys.indexOf(issue.key);
+                const nextKey = keys[keyIdx + 1];
+                const previousKey = keys[keyIdx - 1];
+                const nextString = locales[locale.locale].parsed[nextKey];
+                const siblingString = nextString || locales[locale.locale].parsed[previousKey] || locales[locale.locale].parsed[targetKeys[targetKeys.length - 1]];
+                const contents = locales[locale.locale].contents;
+                const insertAt = contents.indexOf(siblingString) + Number(!nextString ? String(siblingString).length : 0);
+                const comma = !nextString && !siblingString.comma ? `,${siblingString.comment}` : '';
+                const commaOffset = comma ? siblingString.comment.length : 0;
+                const sourceString = `${comma}${locales[sourceLocale].parsed[issue.key]}`;
+                locales[locale.locale].contents = [contents.slice(0, insertAt - commaOffset), sourceString, contents.slice(insertAt)].join('');
+                console.log('Added:', issue.key);
+                locales[locale.locale].parsed[issue.key] = locales[sourceLocale].parsed[issue.key];
+              }
+            }
+            else if (program.translatorOutput) {
+              if (['missing', 'untranslated'].includes(issue.type)) {
+                translatorOutput[issue.key] = issue.source;
+              }
+            }
+            else if (!program.ignoreIssueTypes || !program.ignoreIssueTypes.replace(' ','').split(',').includes(issue.type)) {
+              console.log([
+                '  ', chalk.grey(`${issue.line}:${issue.column}`),
+                '  ', chalk[issue.level == 'error' ? 'red' : 'yellow'](issue.level),
+                ' ', chalk.grey(issue.type),
+                '  ', chalk.cyan(issue.key),
+                '  ', chalk.white(issue.msg)
+              ].join(''));
+            }
+            else {
+              locale.report.totals.ignored += 1;
+            }
+          });
+        }
+
+        if (program.removeExtraneous || program.addMissing || program.sort) {
+          await writeFile(localePath, locales[locale.locale].contents);
+        }
+      }
+
+      if (program.translatorOutput) {
+        console.log(JSON.stringify(translatorOutput, null, 2));
+      }
+
+      if (program.removeExtraneous) {
+        const count = locale.report.errors ? locale.report.errors.extraneous || 0 : 0;
+        const cliReport = `\n ${chalk.green('\u2714')} Removed ${count} extraneous strings`;
+        console.log(cliReport);
+      }
+      else if (program.addMissing) {
+        const count = locale.report.errors ? locale.report.errors.missing || 0 : 0;
+        const cliReport = `\n ${chalk.green('\u2714')} Added ${count} missing strings`;
+        console.log(cliReport);
+      }
+      else if (program.sort) {
+        console.log('\nSorted');
+      }
+      else if (locale.report.totals.errors || locale.report.totals.warnings) {
+        const color = locale.report.totals.errors ? 'red' : 'yellow';
+        const total = locale.report.totals.errors + locale.report.totals.warnings;
+        const cliReport = chalk[color](`\n\u2716 ${total} issues (${locale.report.totals.errors} errors, ${locale.report.totals.warnings} warnings)${locale.report.totals.ignored ? chalk.grey(` - ${locale.report.totals.ignored} Ignored`) : ''}`);
+        console.log(cliReport);
+      }
+      else {
+        const cliReport = `\n ${chalk.green('\u2714')} Passed`;
+        console.log(cliReport);
+      }
+    }
   });
+
+  if (program.throwErrors && output.some(locale => locale.report.totals.errors)) {
+    throw new Error('Errors were reported in at least one locale. See details above.');
+  }
 });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -289,6 +289,7 @@ localesPaths.forEach(async localesPath => {
   });
 
   if (program.throwErrors && output.some(locale => locale.report.totals.errors)) {
-    throw new Error('Errors were reported in at least one locale. See details above.');
+    console.error('\nErrors were reported in at least one locale. See details above.');
+    process.exitCode = 1;
   }
 });

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -77,7 +77,7 @@ localesPaths.forEach(async localesPath => {
 
   const subConfigPath = findConfig('mfv.config.json', { cwd: absLocalesPath });
 
-  const { source, locales: configLocales, jsonObj } = subConfigPath ? await import(subConfigPath, { with: { type: 'json' }}) : {}; /* eslint-disable-line global-require */
+  const { source, locales: configLocales, jsonObj } = subConfigPath ? (await import(subConfigPath, { with: { type: 'json' }}))?.default : {}; /* eslint-disable-line global-require */
 
   const files = await readdir(absLocalesPath).catch(err => console.log(`Failed to read ${absLocalesPath}`));
   if (!files) return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messageformat-validator",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messageformat-validator",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "type": "git",
     "url": "https://github.com/bearfriend/messageformat-validator.git"
   },
-  "main": "src/validate",
+  "main": "src/index.js",
   "scripts": {
     "start": "node index.js",
     "test": "node test.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "messageformat-validator",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Validates that ICU MessageFormat strings are well-formed, and that translated target strings are compatible with their source.",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "https://github.com/bearfriend/messageformat-validator.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.5.1",
+  "version": "2.6.0",
   "description": "Validates that ICU MessageFormat strings are well-formed, and that translated target strings are compatible with their source.",
   "type": "module",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
   "bin": {
     "mfv": "bin/cli.js"
   },
+  "exports": {
+    ".": "./src/index.js"
+  },
+  "files": [
+    "/src"
+  ],
   "author": "Daniel Gleckler <daniel.gleckler@gmail.com>",
   "license": "MIT",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export { Reporter } from './reporter.js';
+export { validateMessage } from './validate.js';

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -8,8 +8,8 @@ export function Reporter(locale, fileContents = '') {
 Reporter.prototype.config = function(targetString, sourceString, key) {
   this.config.key = key || targetString.key;
 
-  if (typeof targetString !== "undefined") this.config.target = targetString.val;
-  if (typeof sourceString !== "undefined") this.config.source = sourceString.val;
+  if (typeof targetString !== "undefined") this.config.target = targetString;
+  if (typeof sourceString !== "undefined") this.config.source = sourceString;
 };
 
 Reporter.prototype.log = function(level, type, msg, column = 0, line) {
@@ -20,8 +20,12 @@ Reporter.prototype.log = function(level, type, msg, column = 0, line) {
   this.report[levels][type] = this.report[levels][type] || 0;
   this.report[levels][type]++;
 
-  const start = Math.max(column || this.config.fileContents.indexOf(this.config.target), 0);
-  const newlines = this.config.target.split(this.config.target.value)[0].match(/\n/)?.length || 0;
+  const start = Math.max(this.config.fileContents.indexOf(this.config.target), 0) + column;
+  const newlines = this.config.target.split(this.config.target.val)[0].match(/\n/)?.length || 0;
+  if (level === 'error') {
+    console.log('Start:', start);
+    console.log(newlines);
+  }
   line = line || this.config.fileContents.substring(0, start).split('\n').length + newlines;
 
   const issue = {
@@ -31,8 +35,8 @@ Reporter.prototype.log = function(level, type, msg, column = 0, line) {
     type,
     level,
     msg,
-    target: this.config.target,
-    source: this.config.source
+    target: this.config.target.val,
+    source: this.config.source.val
   };
 
   if (this.config.key) issue.key = this.config.key;
@@ -77,19 +81,19 @@ Reporter.prototype.error = function(type, msg, details = {}) {
   let column = relativeColumn,
   keyPos, line, linePos, valPos;
 
-  const cleanTarget = this.target
-    .replace(/\n/g, '\\n')
-    .replace(/"/g, '\\"');
-
   if (type === 'missing') {
     column = 0;
   }
   else if (this.config.key) {
     // todo: this seems json-specific
-    keyPos = this.config.fileContents.indexOf(`"${this.config.key}"`);
-    valPos = this.config.fileContents.indexOf(`"${cleanTarget}"`, keyPos);
+    const keyQuote = this.config.target.keyQuote;
+    const valQuote = this.config.target.valQuote;
+    keyPos = this.config.fileContents.indexOf(`${keyQuote}${this.config.key}${keyQuote}`);
+    valPos = this.config.fileContents.indexOf(`${valQuote}${this.config.target.val}${valQuote}`, keyPos);
     linePos = this.config.fileContents.lastIndexOf(String.fromCharCode(10), keyPos);
     column = (valPos + 1) - linePos + relativeColumn;
+    line = this.config.fileContents.substring(0, linePos + column).match(/\n/g).length + 1;
+    column -= this.config.target.lastIndexOf('\n', column);
 
     if (valPos === -1) {
       // the target string likely contains a backslash that does not escape anything

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,6 +1,4 @@
-'use strict';
-
-function Reporter(locale, fileContents) {
+export function Reporter(locale, fileContents) {
   this.locale = locale;
   this.fileContents = fileContents;
   this.report = { totals: { errors: 0, warnings: 0 } };
@@ -100,5 +98,3 @@ Reporter.prototype.error = function(type, msg, details = {}) {
   }
   return this.log('error', type, msg, column, line);
 };
-
-module.exports = { Reporter };

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,4 +1,4 @@
-export function Reporter(locale, fileContents) {
+export function Reporter(locale, fileContents = '') {
   this.locale = locale;
   this.fileContents = fileContents;
   this.report = { totals: { errors: 0, warnings: 0 } };

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -22,10 +22,6 @@ Reporter.prototype.log = function(level, type, msg, column = 0, line) {
 
   const start = Math.max(this.config.fileContents.indexOf(this.config.target), 0) + column;
   const newlines = this.config.target.split(this.config.target.val)[0].match(/\n/)?.length || 0;
-  if (level === 'error') {
-    console.log('Start:', start);
-    console.log(newlines);
-  }
   line = line || this.config.fileContents.substring(0, start).split('\n').length + newlines;
 
   const issue = {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -1,15 +1,15 @@
 export function Reporter(locale, fileContents = '') {
-  this.locale = locale;
-  this.fileContents = fileContents;
+  this.config.locale = locale;
+  this.config.fileContents = fileContents;
   this.report = { totals: { errors: 0, warnings: 0 } };
   this.issues = [];
 }
 
-Reporter.prototype.config = function(targetString, sourceString) {
-  this.key = targetString.key;
+Reporter.prototype.config = function(targetString, sourceString, key) {
+  this.config.key = key || targetString.key;
 
-  if (typeof targetString !== "undefined") this.target = targetString;
-  if (typeof sourceString !== "undefined") this.source = sourceString;
+  if (typeof targetString !== "undefined") this.config.target = targetString.val;
+  if (typeof sourceString !== "undefined") this.config.source = sourceString.val;
 };
 
 Reporter.prototype.log = function(level, type, msg, column = 0, line) {
@@ -20,22 +20,22 @@ Reporter.prototype.log = function(level, type, msg, column = 0, line) {
   this.report[levels][type] = this.report[levels][type] || 0;
   this.report[levels][type]++;
 
-  const start = Math.max(column || this.fileContents.indexOf(this.target), 0);
-  const newlines = this.target.split(this.target.value)[0].match(/\n/)?.length || 0;
-  line = line || this.fileContents.substring(0, start).split('\n').length + newlines;
+  const start = Math.max(column || this.config.fileContents.indexOf(this.config.target), 0);
+  const newlines = this.config.target.split(this.config.target.value)[0].match(/\n/)?.length || 0;
+  line = line || this.config.fileContents.substring(0, start).split('\n').length + newlines;
 
   const issue = {
-    locale: this.locale,
+    locale: this.config.locale,
     line,
     column,
     type,
     level,
     msg,
-    target: this.target,
-    source: this.source
+    target: this.config.target,
+    source: this.config.source
   };
 
-  if (this.key) issue.key = this.key;
+  if (this.config.key) issue.key = this.config.key;
 
   this.issues.push(issue);
 
@@ -48,17 +48,17 @@ Reporter.prototype.warning = function(type, msg, details = {}) {
 
   let column, keyPos, linePos, valPos;
 
-  const cleanTarget = this.target
+  const cleanTarget = this.config.target
     .replace(/\n/g, '\\n')
     .replace(/"/g, '\\"');
 
   if (['split', 'newline'].includes(type)) {
     column = 0;
   }
-  else if (this.key) {
-    keyPos = this.fileContents.indexOf(`"${this.key}"`);
-    valPos = this.fileContents.indexOf(`"${cleanTarget}"`, keyPos);
-    linePos = this.fileContents.lastIndexOf(String.fromCharCode(10), keyPos);
+  else if (this.config.key) {
+    keyPos = this.config.fileContents.indexOf(`"${this.config.key}"`);
+    valPos = this.config.fileContents.indexOf(`"${cleanTarget}"`, keyPos);
+    linePos = this.config.fileContents.lastIndexOf(String.fromCharCode(10), keyPos);
     column = (valPos + 1) - linePos + relativeColumn;
 
     if (valPos === -1) {
@@ -84,11 +84,11 @@ Reporter.prototype.error = function(type, msg, details = {}) {
   if (type === 'missing') {
     column = 0;
   }
-  else if (this.key) {
+  else if (this.config.key) {
     // todo: this seems json-specific
-    keyPos = this.fileContents.indexOf(`"${this.key}"`);
-    valPos = this.fileContents.indexOf(`"${cleanTarget}"`, keyPos);
-    linePos = this.fileContents.lastIndexOf(String.fromCharCode(10), keyPos);
+    keyPos = this.config.fileContents.indexOf(`"${this.config.key}"`);
+    valPos = this.config.fileContents.indexOf(`"${cleanTarget}"`, keyPos);
+    linePos = this.config.fileContents.lastIndexOf(String.fromCharCode(10), keyPos);
     column = (valPos + 1) - linePos + relativeColumn;
 
     if (valPos === -1) {

--- a/src/validate.js
+++ b/src/validate.js
@@ -92,7 +92,7 @@ export function validateMessage({ targetString, targetLocale, sourceString, sour
       msgReporter.error('brace', 'Mismatched braces (i.e. {}). ' + e.message, { column: e.location.start.column });
     }
     else {
-      msgReporter.error('parse', e.message, { column: e.location.start.column });
+      msgReporter.error('parse', e.message, { column: e.location.start.column - 1 });
     }
   }
 
@@ -150,7 +150,6 @@ export function validateMessage({ targetString, targetLocale, sourceString, sour
     }
 
     if (targetTokens.length > 1) {
-
       if (targetLocale == sourceLocale && targetTokens.find((token) => typeof token !== 'string' && token.type.match(/plural|select/))) {
         msgReporter.warning('split','String split by non-argument (e.g. select; plural).')
       }

--- a/src/validate.js
+++ b/src/validate.js
@@ -77,7 +77,7 @@ export function validateMessage({ targetString, targetLocale, sourceString, sour
 
   let parsedTarget;
   try {
-    parsedTarget = Object.freeze(parse(targetString, pluralCats[targetLocale.split('-')[0]));
+    parsedTarget = Object.freeze(parse(targetString, pluralCats[targetLocale.split('-')[0]]));
   }
   catch(e) {
 

--- a/src/validate.js
+++ b/src/validate.js
@@ -109,6 +109,20 @@ export function validateMessage({ targetString, targetLocale, sourceString, sour
       return;
     }
 
+    const checkOther = target => {
+      target?.forEach(part => {
+        if (['select', 'selectordinal', 'plural'].includes(part.type)) {
+          const hasOther = part.cases.find(c => c.key === 'other');
+          if (!hasOther) {
+            msgReporter.error('other', 'Missing "other" case');
+          }
+        }
+        checkOther(target.cases);
+      });
+    };
+
+    checkOther(parsedTarget);
+
     const targetMap = _map(targetTokens);
     const sourceMap = _map(sourceTokens);
 

--- a/src/validate.js
+++ b/src/validate.js
@@ -125,11 +125,6 @@ export function validateMessage({ targetString, targetLocale, sourceString, sour
     // remove all translated content, leaving only the messageformat structure
     const structure = targetString.match(structureRegEx)?.join('') || '';
 
-    const newlinePos = structure.indexOf(String.fromCharCode(10));
-    if (newlinePos > -1) {
-      msgReporter.warning('newline', 'String contains unnecessary newline(s).', { column: newlinePos });
-    }
-
     const nbspPos = structure.indexOf(String.fromCharCode(160));
     if (nbspPos > -1) {
       msgReporter.error('nbsp', `String contains invalid non-breaking space at position ${nbspPos}.`, { column: nbspPos });

--- a/src/validate.js
+++ b/src/validate.js
@@ -64,7 +64,7 @@ export function validateMessage({ targetString, targetLocale, sourceString, sour
     && targetLocale !== sourceLocale
     && targetString.replace(re,'') === sourceString.replace(re,'')) {
 
-      if (!overrides.includes('translated')
+      if (!overrides?.includes('translated')
         && sourceString
           .replace(structureRegEx, '')
           .replace(re,'')

--- a/src/validate.js
+++ b/src/validate.js
@@ -1,3 +1,4 @@
+import * as pluralCats from 'make-plural/pluralCategories'
 import { Reporter } from './reporter.js';
 import { parse } from 'messageformat-parser';
 
@@ -76,9 +77,7 @@ export function validateMessage({ targetString, targetLocale, sourceString, sour
 
   let parsedTarget;
   try {
-    const pluralCats = new Intl.PluralRules(targetLocale, { type: 'cardinal' }).resolvedOptions().pluralCategories;
-    const ordinalCats = new Intl.PluralRules(targetLocale, { type: 'ordinal' }).resolvedOptions().pluralCategories;
-    parsedTarget = Object.freeze(parse(targetString, { pluralCats, ordinalCats }));
+    parsedTarget = Object.freeze(parse(targetString, pluralCats[targetLocale]));
   }
   catch(e) {
 
@@ -103,9 +102,7 @@ export function validateMessage({ targetString, targetLocale, sourceString, sour
     let sourceTokens;
 
     try {
-      const pluralCats = new Intl.PluralRules(sourceLocale, { type: 'cardinal' }).resolvedOptions().pluralCategories;
-      const ordinalCats = new Intl.PluralRules(sourceLocale, { type: 'ordinal' }).resolvedOptions().pluralCategories;
-      sourceTokens = parse(sourceString, { pluralCats, ordinalCats });
+      sourceTokens = parse(sourceString, pluralCats[sourceLocale]);
     }
     catch(e) {
       msgReporter.error('source-error', 'Failed to parse source string.');

--- a/src/validate.js
+++ b/src/validate.js
@@ -77,7 +77,7 @@ export function validateMessage({ targetString, targetLocale, sourceString, sour
 
   let parsedTarget;
   try {
-    parsedTarget = Object.freeze(parse(targetString, pluralCats[targetLocale]));
+    parsedTarget = Object.freeze(parse(targetString, pluralCats[targetLocale.split('-')[0]));
   }
   catch(e) {
 
@@ -102,7 +102,7 @@ export function validateMessage({ targetString, targetLocale, sourceString, sour
     let sourceTokens;
 
     try {
-      sourceTokens = parse(sourceString, pluralCats[sourceLocale]);
+      sourceTokens = parse(sourceString, pluralCats[sourceLocale.split('-')[0]]);
     }
     catch(e) {
       msgReporter.error('source-error', 'Failed to parse source string.');


### PR DESCRIPTION
- Moves from commonjs to esm
- Provides exports for use in js
- Fixes `translatorOutput`
- Fixes _some_ issue line:column numbers
  - The parsing library gets some of these wrong
  - Switching to formatjs parsing would be ideal