### PR TITLE
Fix JSON import paths in Windows

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,7 +11,8 @@ import pkg from '../package.json' with { type: 'json' };
 import { validateLocales, parseLocales, structureRegEx } from '../src/validate.js';
 
 const configPath = findConfig('mfv.config.json');
-const { path, source: globalSource, locales: globalLocales, jsonObj: globalJsonObj } = configPath ? (await import(configPath, { with: { type: 'json' }}))?.default : {};
+console.log(configPath);
+const { path, source: globalSource, locales: globalLocales, jsonObj: globalJsonObj } = configPath ? (await import(`file://${configPath}`, { with: { type: 'json' }}))?.default : {};
 
 program
   .version(pkg.version)
@@ -77,7 +78,7 @@ localesPaths.forEach(async localesPath => {
 
   const subConfigPath = findConfig('mfv.config.json', { cwd: absLocalesPath });
 
-  const { source, locales: configLocales, jsonObj } = subConfigPath ? (await import(subConfigPath, { with: { type: 'json' }}))?.default : {}; /* eslint-disable-line global-require */
+  const { source, locales: configLocales, jsonObj } = subConfigPath ? (await import(`file://${subConfigPath}`, { with: { type: 'json' }}))?.default : {}; /* eslint-disable-line global-require */
 
   const files = await readdir(absLocalesPath).catch(err => console.log(`Failed to read ${absLocalesPath}`));
   if (!files) return;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -11,7 +11,6 @@ import pkg from '../package.json' with { type: 'json' };
 import { validateLocales, parseLocales, structureRegEx } from '../src/validate.js';
 
 const configPath = findConfig('mfv.config.json');
-console.log(configPath);
 const { path, source: globalSource, locales: globalLocales, jsonObj: globalJsonObj } = configPath ? (await import(`file://${configPath}`, { with: { type: 'json' }}))?.default : {};
 
 program

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messageformat-validator",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messageformat-validator",
-      "version": "2.6.1",
+      "version": "2.6.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "description": "Validates that ICU MessageFormat strings are well-formed, and that translated target strings are compatible with their source.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
Fixes JSON import paths in Windows, which requires a `file://` prefix