### PR TITLE
Handle line calculation failures gracefully

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messageformat-validator",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messageformat-validator",
-      "version": "2.6.2",
+      "version": "2.6.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "Validates that ICU MessageFormat strings are well-formed, and that translated target strings are compatible with their source.",
   "type": "module",
   "repository": {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -88,7 +88,7 @@ Reporter.prototype.error = function(type, msg, details = {}) {
     valPos = this.config.fileContents.indexOf(`${valQuote}${this.config.target.val}${valQuote}`, keyPos);
     linePos = this.config.fileContents.lastIndexOf(String.fromCharCode(10), keyPos);
     column = (valPos + 1) - linePos + relativeColumn;
-    line = this.config.fileContents.substring(0, linePos + column).match(/\n/g).length + 1;
+    line = (this.config.fileContents.substring(0, linePos + column).match(/\n/g)?.length ?? -1) + 1;
     column -= this.config.target.lastIndexOf('\n', column);
 
     if (valPos === -1) {


### PR DESCRIPTION
If line calculation fails, set to `0` instead of throwing an error.