### PR TITLE
Handle reporter target and source as primitive strings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "messageformat-validator",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "messageformat-validator",
-      "version": "2.6.4",
+      "version": "2.6.5",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "messageformat-validator",
-  "version": "2.6.4",
+  "version": "2.6.5",
   "description": "Validates that ICU MessageFormat strings are well-formed, and that translated target strings are compatible with their source.",
   "type": "module",
   "repository": {

--- a/src/reporter.js
+++ b/src/reporter.js
@@ -8,7 +8,6 @@ export function Reporter(locale, fileContents = '') {
 
 Reporter.prototype.config = function(targetString, sourceString, key) {
   this._config.key = key || targetString.key;
-
   if (typeof targetString !== "undefined") this._config.target = targetString;
   if (typeof sourceString !== "undefined") this._config.source = sourceString;
 };
@@ -32,8 +31,8 @@ Reporter.prototype.log = function(level, type, msg, column = 0, line) {
     type,
     level,
     msg,
-    target: this._config.target.val,
-    source: this._config.source.val
+    target: this._config.target.val || this._config.target,
+    source: this._config.source.val || this._config.source
   };
 
   if (this._config.key) issue.key = this._config.key;


### PR DESCRIPTION
If primitives are sent to `reporter.config`, they should be used instead for `target` and `source`