### PR TITLE
fix: Throw an explicit error if source is not provided

### DIFF
--- a/src/validate.js
+++ b/src/validate.js
@@ -11,6 +11,8 @@ let reporter;
 
 export function validateLocales({ locales, sourceLocale }) {
 
+  if (!sourceLocale) throw new Error('Must provide the source locale file using either the -s option or a config file.');
+
   const sourceStrings = locales[sourceLocale].parsed;
 
   return Object.keys(locales).map((targetLocale) => {


### PR DESCRIPTION
First time using `mfv` so it wasn't obvious to me that I had to specify a source file (should've looked at examples in README 🤦). This was the error I was getting on [validate.js line 14](https://github.com/bearfriend/messageformat-validator/blob/master/src/validate.js#L14). Would be nice to have a more explicit error.
```
TypeError: Cannot read properties of undefined (reading 'parsed')
    at validateLocales (file:///C:/D2L/github/folio-components/node_modules/messageformat-validator/src/validate.js:16:47)
    at file:///C:/D2L/github/folio-components/node_modules/messageformat-validator/bin/cli.js:182:18
```